### PR TITLE
Update ArcanistGoLintLinter install instructions

### DIFF
--- a/src/lint/linter/ArcanistGoLintLinter.php
+++ b/src/lint/linter/ArcanistGoLintLinter.php
@@ -29,7 +29,7 @@ final class ArcanistGoLintLinter extends ArcanistExternalLinter {
   public function getInstallInstructions() {
     return pht(
       'Install Golint using `%s`.',
-      'go get github.com/golang/lint/golint');
+      'go get golang.org/x/lint/golint');
   }
 
   public function shouldExpectCommandErrors() {


### PR DESCRIPTION
Old path no longer works and throws a missing package error. 
See [this issue](https://github.com/golang/lint/issues/415).